### PR TITLE
Added .addPropertyValue and .addObjectPropertyValue to ValueNode

### DIFF
--- a/src/main/java/com/epimorphics/dclib/values/ValueArray.java
+++ b/src/main/java/com/epimorphics/dclib/values/ValueArray.java
@@ -11,6 +11,9 @@ package com.epimorphics.dclib.values;
 
 import com.epimorphics.dclib.framework.ConverterProcess;
 import com.epimorphics.util.NameUtils;
+
+import java.util.ArrayList;
+
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.TypeMapper;
 import org.apache.jena.graph.Node;
@@ -315,6 +318,37 @@ public class ValueArray extends ValueBase<Value[]> implements Value {
         }
         return new ValueArray(result);
     }
+    
+    public String toString() {
+    	StringBuilder sb = new StringBuilder() ;
+    	if (value == null) 
+    		return null;
+    	boolean first = true;
+    	sb.append('[');
+    	
+    	for(Value v : value) {
+    		sb.append(first ? "" : " | ");
+    		sb.append(v.toString()) ;
+    		first = false;
+    	}
+    	sb.append(']');
+    	return sb.toString();
+    }
+    
+//    public ValueArray flatten() { 
+//    	ArrayList<Value> result = new ArrayList<Value>() ;
+//    	Value[] a = null;
+//    	for (Value v : value) {
+//    		if(v instanceof ValueArray) {
+//    			ValueArray values = ((ValueArray) v).flatten();
+//    			for (Value x : values.getValues()) 
+//    				result.add(x);
+//    		}
+//    		else result.add(v);    		
+//    	}
+//    	a = result.toArray(a);
+//    	return new ValueArray(a);
+//    }
 }
 
 

--- a/src/main/java/com/epimorphics/dclib/values/ValueNode.java
+++ b/src/main/java/com/epimorphics/dclib/values/ValueNode.java
@@ -240,21 +240,57 @@ public class ValueNode extends ValueBase<Node> implements Value{
             return prop;
         }
     }
+
+    public ValueNode addPropertyValue(String p, String o) {
+    	return addPropertyValue(new ValueString(p),  new ValueString(o)) ;
+    }
     
+    public ValueNode addPropertyValue(Value p, String o) {
+    	return addPropertyValue(p,  new ValueString(o)) ;
+    }
+
+    public ValueNode addPropertyValue(String p, Value o) {
+    	return addPropertyValue(new ValueString(p), o) ;
+    }
+
     public ValueNode addPropertyValue(Value p, Value o) {
         ConverterProcess proc = ConverterProcess.get();
         StreamRDF        out = proc.getOutputStream();
         ModelWrapper     model = new ModelWrapper(proc.getModel());
-      
-        Property prop = model.getModel().createProperty(model.getResource(p.toString()).getURI());
-        Resource val  = model.getResource(o.toString());
-        
-        out.triple(new Triple(this.asNode(), prop.asNode(), val.asNode()));
+
+        Resource prop = model.getResource(p.toString());
+  
+        out.triple(new Triple(this.asNode(), prop.asNode(), o.asNode()));
 //        model.getModel().add(this.asResource(), prop, (RDFNode) val);
     
     	return this;
     }
     
+    public ValueNode addObjectPropertyValue(String p, String o) {
+    	return addObjectPropertyValue(new ValueString(p),  new ValueString(o)) ;
+    }
+    
+    public ValueNode addObjectPropertyValue(Value p, String o) {
+    	return addObjectPropertyValue(p,  new ValueString(o)) ;
+    }
+
+    public ValueNode addObjectPropertyValue(String p, Value o) {
+    	return addObjectPropertyValue(new ValueString(p), o) ;
+    }
+
+    public ValueNode addObjectPropertyValue(Value p, Value o) {
+        ConverterProcess proc = ConverterProcess.get();
+        StreamRDF        out = proc.getOutputStream();
+        ModelWrapper     model = new ModelWrapper(proc.getModel());
+
+        Resource prop = model.getResource(p.toString());
+        Resource res  = model.getResource(o.toString());
+  
+        out.triple(new Triple(this.asNode(), prop.asNode(), res.asNode()));
+//        model.getModel().add(this.asResource(), prop, (RDFNode) val);
+    
+    	return this;
+    }
     public static class PropertyValue implements Comparable<PropertyValue> {
 
         protected ValueNode prop;

--- a/src/main/java/com/epimorphics/dclib/values/ValueNode.java
+++ b/src/main/java/com/epimorphics/dclib/values/ValueNode.java
@@ -12,13 +12,17 @@ package com.epimorphics.dclib.values;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.riot.system.StreamRDF;
+
 import com.epimorphics.dclib.framework.ConverterProcess;
 import com.epimorphics.rdfutil.ModelWrapper;
 import com.epimorphics.rdfutil.RDFNodeWrapper;
-import org.apache.jena.graph.Node;
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
 
 public class ValueNode extends ValueBase<Node> implements Value{
     RDFNodeWrapper wnode;
@@ -236,6 +240,21 @@ public class ValueNode extends ValueBase<Node> implements Value{
             return prop;
         }
     }
+    
+    public ValueNode addPropertyValue(Value p, Value o) {
+        ConverterProcess proc = ConverterProcess.get();
+        StreamRDF        out = proc.getOutputStream();
+        ModelWrapper     model = new ModelWrapper(proc.getModel());
+      
+        Property prop = model.getModel().createProperty(model.getResource(p.toString()).getURI());
+        Resource val  = model.getResource(o.toString());
+        
+        out.triple(new Triple(this.asNode(), prop.asNode(), val.asNode()));
+//        model.getModel().add(this.asResource(), prop, (RDFNode) val);
+    
+    	return this;
+    }
+    
     public static class PropertyValue implements Comparable<PropertyValue> {
 
         protected ValueNode prop;

--- a/src/test/java/com/epimorphics/dclib/values/TestValueNode.java
+++ b/src/test/java/com/epimorphics/dclib/values/TestValueNode.java
@@ -1,0 +1,89 @@
+/******************************************************************
+ * File:        TestValueNode.java   
+ * Created by:  Stuart Williams (skw@epimorphics.com)
+ * Created on:  29 May 2018
+ * 
+ * (c) Copyright 2018, Epimorphics Limited
+ *  *
+ *****************************************************************/
+package com.epimorphics.dclib.values;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.util.FileManager;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.epimorphics.dclib.framework.BindingEnv;
+import com.epimorphics.dclib.framework.ConverterProcess;
+import com.epimorphics.dclib.framework.DataContext;
+import com.epimorphics.dclib.framework.Pattern;
+
+/**
+ * @author skw
+ *
+ */
+public class TestValueNode {
+	
+	DataContext dc = new DataContext();
+	BindingEnv env;
+	ConverterProcess proc;
+	
+	public TestValueNode() {
+	}
+	
+	@Before
+	public void setUp() {
+		// Need to set prefixes in DC *before* creating the converter process.
+		dc.setPrefixes( FileManager.get().loadModel("prefixes.ttl") );
+		proc = new ConverterProcess(dc, null);
+		env = new BindingEnv();
+		env.set("u", ValueFactory.asValue("http://example.com/foo"));
+	}
+	
+	@Test
+	public void testAddProperty() {
+		// Make sure the result model is empty before we start.
+		assertFalse(proc.getModel().listStatements().hasNext());
+		Resource r = (Resource) eval(
+				  "{"
+				+ "u.asRDFNode()"
+				+ ".addPropertyValue(       'rdfs:label',                         'This is a test@en')"									 // String,String
+				+ ".addPropertyValue(       'dct:created',                        value('2018-05-29T12:24:00Z').asDate('xsd:dateTime'))" // String, ValueDate
+				+ ".addPropertyValue(       'dct:hasVersion',                     value('10.5').asDecimal())"                          	 // String, ValueNumber
+				+ ".addObjectPropertyValue( 'dct:isVersionOf',                   'http://example.com/bar')"                   		     // String, String
+				+ ".addObjectPropertyValue( value('dct:isVersionOf').asRDFNode(), value('http://example.com/bar2'))"                     // ValueNode, ValueNode
+				+ ".asResource()"
+				+ "}"
+			    );
+	
+		assertTrue("Missing or unexpected rdfs:label value",                 proc.getModel().contains(r, RDFS.label,proc.getModel().createLiteral("This is a test","en")));
+		assertTrue("Missing or unexpected dct:created value",                proc.getModel().contains(r, DCTerms.created,proc.getModel().createTypedLiteral("2018-05-29T12:24:00Z",XSDDatatype.XSDdateTime)));
+		assertTrue("Missing or unexpected dct:hasVersion (decimal) value",   proc.getModel().contains(r, DCTerms.hasVersion,proc.getModel().createTypedLiteral(BigDecimal.valueOf(10.5))));
+		assertTrue("Missing or unexpected dct:isVersionOf (resource) value", proc.getModel().contains(r, DCTerms.isVersionOf, proc.getModel().getResource("http://example.com/bar")));
+		assertTrue("Missing or unexpected dct:isVersionOf (resource) value", proc.getModel().contains(r, DCTerms.isVersionOf, proc.getModel().getResource("http://example.com/bar2")));		
+	}
+	
+	private Object eval(String pattern) {
+		return proc.evaluate(new Pattern(pattern, dc), env, 0);
+	}
+	
+	private Node evalNode(String pattern) {
+		return proc.evaluateAsNode(new Pattern(pattern, dc), env, 0);
+	}
+	
+}


### PR DESCRIPTION
I've added two functions, `.addPropertyValue(...)` and `.addObjectPropertyValue(...)` and  to `ValueNode` (along with parameter variations for String and Value arguments). These are to enable Jexl scripts to added triples to the results graph which is required when processing some more complex cells that carry multiple values (say, `|` separated and broken apart with `.split('\\\\|')`.

I've also added a `.toString() `to `ValueArray` that give more useful debugging output when using `print()` within a Jexl Script.  There is also a commented out `ValueArray.flatten()` that flattens nested array structure into a single `ValueArray` however the difficulty in creating such structures makes this function somewhat redundant.

Also added a test case for `.addPropertyValue` and `.addObjectPropertyValue`.