### PR TITLE
Modified: Object value(Object value) global method

### DIFF
--- a/src/main/java/com/epimorphics/dclib/values/GlobalFunctions.java
+++ b/src/main/java/com/epimorphics/dclib/values/GlobalFunctions.java
@@ -109,7 +109,22 @@ public class GlobalFunctions {
     
     /** Wrap a plain object as a Value */
     public static Object value(Object value) {
-        if (value instanceof Value) {
+  
+    	if(value instanceof Object[] ) {
+    		Object[] oa = (Object[] )value;
+    		int len = oa.length;
+        	Value[] v = new Value[len] ;
+        	for(int i=0; i<len; i++) {
+        		Object wrapped = value(oa[i]);
+        		if ( !(wrapped instanceof Value) ) {
+        			throw new EpiException("Can't wrap array/collection member:" + oa[i] +" as a Value()");
+        		}
+        		v[i] = (Value) value(oa[i]);
+        	}
+        	return new ValueArray(v);
+    	}
+
+    	if (value instanceof Value) {
             return value;
         } else if (value instanceof String) {
             return new ValueString((String)value);
@@ -118,6 +133,10 @@ public class GlobalFunctions {
         } else {
             return value;
         }
+    }
+    
+    public static Object value(Collection<Object> values) {
+    	return value(values.toArray(new Object[values.size()]));
     }
     
     /** Convert a URI string to a resource, expanding any prefixes */

--- a/src/main/java/com/epimorphics/dclib/values/GlobalFunctions.java
+++ b/src/main/java/com/epimorphics/dclib/values/GlobalFunctions.java
@@ -11,6 +11,7 @@ package com.epimorphics.dclib.values;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -109,9 +110,12 @@ public class GlobalFunctions {
     
     /** Wrap a plain object as a Value */
     public static Object value(Object value) {
-  
-    	if(value instanceof Object[] ) {
-    		Object[] oa = (Object[] )value;
+        
+    	if(value.getClass().isArray()) {
+	        Object[] oa = (value instanceof int[] )    ? (Object[] ) (Arrays.stream((int[])    value).boxed().toArray()) :
+    	                  (value instanceof long[] )   ? (Object[] ) (Arrays.stream((long[])   value).boxed().toArray()) :
+          	              (value instanceof double[] ) ? (Object[] ) (Arrays.stream((double[]) value).boxed().toArray()) :
+		    		      (Object[] )value;
     		int len = oa.length;
         	Value[] v = new Value[len] ;
         	for(int i=0; i<len; i++) {

--- a/src/test/java/com/epimorphics/dclib/values/TestValueArray.java
+++ b/src/test/java/com/epimorphics/dclib/values/TestValueArray.java
@@ -1,0 +1,100 @@
+/******************************************************************
+ * File:        TestValueArray.java   
+ * Created by:  Stuart Williams (skw@epimorphics.com)
+ * Created on:  15 Oct 2020
+ * 
+ * (c) Copyright 2020, Epimorphics Limited
+ *  *
+ *****************************************************************/
+package com.epimorphics.dclib.values;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.jena.util.FileManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.epimorphics.dclib.framework.BindingEnv;
+import com.epimorphics.dclib.framework.ConverterProcess;
+import com.epimorphics.dclib.framework.DataContext;
+import com.epimorphics.dclib.framework.Pattern;
+
+/**
+ * @author skw
+ *
+ */
+public class TestValueArray {
+	
+	DataContext dc = new DataContext();
+	BindingEnv env;
+	ConverterProcess proc;
+	
+	public TestValueArray() {
+	}
+	
+	@Before
+	public void setUp() {
+		// Need to set prefixes in DC *before* creating the converter process.
+		dc.setPrefixes( FileManager.get().loadModel("prefixes.ttl") );
+		proc = new ConverterProcess(dc, null);
+		env = new BindingEnv();
+		env.set("u", ValueFactory.asValue("http://example.com/foo"));
+	}
+	
+	@Test
+	public void testCreateFromArrayAndCollection() {
+		// Make sure the result model is empty before we start.
+		assertFalse(proc.getModel().listStatements().hasNext());
+		//Use split to create a ValueArray and then use .value to reach the underlying array
+		Value  t = (Value) eval( "{ { var res = [ 'a', 'b', 'c', 'd', 'e' ]; return (value(res)) } } ");
+		Value  u = (Value) eval( "{ { var res = [ 6, 7, 8, 9, 10]; return (value(res)) } } ");
+		Value  v = (Value) eval( "{value( value('one|two|three|4|rdfs:label').split('\\|').value ) }" );
+		Value  w = (Value) eval( "{ { var res=({1:1}) ;\n"   // make a map
+				                + "    res.clear()     ;\n"  // empty it
+				                + "    res.put(1,1)    ;\n"  // add some entires
+				                + "    res.put(2,2)    ;\n"
+				                + "    res.put(3,3)    ;\n"
+				                + "    res.put(4,4)    ;\n"
+				                + "    res.put(5,5)    ;\n"
+				                + "    return value(res.keySet()) } }" ) ;  // return it's key set.
+		
+		String[] t_s = {"a", "b", "c", "d", "e"} ;
+	    ValueArray t_= new ValueArray(  t_s ) ;
+	    
+	    assertTrue("Failed to match array of strings",     Arrays.equals( (Value[])t.getValue(), (Value [])t_.getValue() ) ) ;
+	    assertTrue("Failed to match integers", 
+ 		                ((ValueArray)u).get(0).equals(value(6)) &&
+	                    ((ValueArray)u).get(1).equals(value(7)) &&
+                        ((ValueArray)u).get(2).equals(value(8)) &&
+                        ((ValueArray)u).get(3).equals(value(9)) &&
+                        ((ValueArray)u).get(4).equals(value(10))
+                  ) ;
+	    assertTrue("Failed to match values from split", 		                
+	    		        ((ValueArray)v).get(0).equals(value("one")) &&
+                        ((ValueArray)v).get(1).equals(value("two")) &&
+                        ((ValueArray)v).get(2).equals(value("three")) &&
+                        ((ValueArray)v).get(3).equals(value("4")) &&
+                        ((ValueArray)v).get(4).equals(value("rdfs:label"))
+                );
+	    assertTrue("Failed to match values from collection" , 
+	                    ((ValueArray)w).get(0).equals(value(1)) &&
+                        ((ValueArray)w).get(1).equals(value(2)) &&
+                        ((ValueArray)w).get(2).equals(value(3)) &&
+                        ((ValueArray)w).get(3).equals(value(4)) &&
+                        ((ValueArray)w).get(4).equals(value(5))
+          ) ;
+	    
+	}
+	
+	private Object eval(String pattern) {
+		return proc.evaluate(new Pattern(pattern, dc), env, 0);
+	}
+	
+	private Value value(Object o) {
+		return (Value) GlobalFunctions.value(o);
+	}
+		
+}


### PR DESCRIPTION
I've updated dclib in a branch such that the global value methods will accept array or collections of values to generate a ValueArray result. It does require that all the values in the array or collection can be coerced to be instances `Value`  and error handling is a little crude if they can't.

Also I am at a loss as to how and where I can easily add some test coverage for these additions.