### PR TITLE
Update to ValueBase and ArrayValue to implement array functions `.asRDFNode()` and `asResource()`.

### DIFF
--- a/src/main/java/com/epimorphics/dclib/values/ValueArray.java
+++ b/src/main/java/com/epimorphics/dclib/values/ValueArray.java
@@ -156,6 +156,25 @@ public class ValueArray extends ValueBase<Value[]> implements Value {
     }    
     
     @Override
+    public Value asRDFNode() {
+        return applyFunction(new MapValue() {
+            public Value map(Value value) {
+				@SuppressWarnings("rawtypes")
+				Value v = ((ValueBase) value).asRDFNode() ;
+                return v;
+            }
+        });
+    }    
+    
+    public Value asResource() {
+        return applyFunction(new MapValue() {
+            public Value map(Value value) {
+            	return GlobalFunctions.asResource((Object) value);
+            }
+        });
+    }
+    
+    @Override
     public Value map(final String mapsource, final boolean matchRequired) {
         return applyFunction(new MapValue() {
             @SuppressWarnings("rawtypes")

--- a/src/main/java/com/epimorphics/dclib/values/ValueArray.java
+++ b/src/main/java/com/epimorphics/dclib/values/ValueArray.java
@@ -159,8 +159,8 @@ public class ValueArray extends ValueBase<Value[]> implements Value {
     public Value asRDFNode() {
         return applyFunction(new MapValue() {
             public Value map(Value value) {
-				@SuppressWarnings("rawtypes")
-				Value v = ((ValueBase) value).asRDFNode() ;
+                @SuppressWarnings("rawtypes")
+                Value v = ((ValueBase) value).asRDFNode() ;
                 return v;
             }
         });

--- a/src/main/java/com/epimorphics/dclib/values/ValueBase.java
+++ b/src/main/java/com/epimorphics/dclib/values/ValueBase.java
@@ -349,7 +349,7 @@ public abstract class ValueBase<T> implements Value {
 
     
     /** Convert to a wrapped RDF node, treats strings as a URI and creates a resource node */
-    public ValueNode asRDFNode() {
+    public Value asRDFNode() {
         return new ValueNode( NodeFactory.createURI( value.toString() ) );
     }
     


### PR DESCRIPTION
I've added two functions to `ValueArray` to implement `.asRDFNode()` and `asResource()` to generate an array of `ValueNode`s. I had to relax the range of `ValueBase.asRDFNode()` to being `Value` rather than `ValueNode` in order to admit `ValueArray` as a possible result type. The commit builds and passes its test, so I don't think that relaxation has caused a problem, though I'm wary that it might have.