### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.0.2-SNAPSHOT]
+
+* Update appbase 4.0.0 -> 4.0.6 to address transitive dependency vulnerabilities.
+* Update test dependency on logback-classic 1.5.32 -> 1.5.34 to address transitive dependency vulnerabilities.

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>appbase</artifactId>
-      <version>4.0.0</version>
+      <version>4.0.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -114,7 +114,7 @@
     <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.5.32</version>
+        <version>1.5.34</version>
         <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
* appbase 4.0.0 -> 4.0.6 to address the bulk of the dependabot alerts
* logback-classic 1.5.32 -> 1.5.34 to address the alert relating to logback-core.