### PR TITLE
Chore/deps updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2]
+
+* Update appbase to 4.0.6 to address transitive dependency vulnerabilities.
+
 ## [3.0.2-SNAPSHOT]
 
 * Update appbase 4.0.0 -> 4.0.6 to address transitive dependency vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.2]
 
-* Update appbase to 4.0.6 to address transitive dependency vulnerabilities.
-
-## [3.0.2-SNAPSHOT]
-
-* Update appbase 4.0.0 -> 4.0.6 to address transitive dependency vulnerabilities.
+* Update appbase to 4.0.7 to address transitive dependency vulnerabilities.
 * Update test dependency on logback-classic 1.5.32 -> 1.5.34 to address transitive dependency vulnerabilities.
 * Add toCamelCaseSegment formatting option on ValueBase.
 * Add percentage completion to progress logs.

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>appbase</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Trying to bump appbase version to fix transitive vulnerabilities so as to be able to update dms.

This does pull in recent issue fixes as a side-effect.